### PR TITLE
Correct wordpress/schema.yaml to adjusted form schema spec.

### DIFF
--- a/wordpress/schema.yaml
+++ b/wordpress/schema.yaml
@@ -73,5 +73,5 @@ required:
 - customBoolean
 - reportingSecret
 form:
-- widget: helper
+- widget: help
   description: My arbitrary <i>description</i>

--- a/wordpress/schema.yaml
+++ b/wordpress/schema.yaml
@@ -73,5 +73,5 @@ required:
 - customBoolean
 - reportingSecret
 form:
-- type: text
+- widget: helper
   description: My arbitrary <i>description</i>


### PR DESCRIPTION
See latter commits in https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/pull/223.