### PR TITLE
Add MARKETPLACE_TOOLS_TAG to wordpress example.

### DIFF
--- a/wordpress/Makefile
+++ b/wordpress/Makefile
@@ -67,6 +67,7 @@ app/build:: .build/marketplace/dev \
 	docker build \
 	    --build-arg REGISTRY="$(REGISTRY)/example/wordpress" \
 	    --build-arg TAG="$(TAG)" \
+	    --build-arg MARKETPLACE_TOOLS_TAG="$(MARKETPLACE_TOOLS_TAG)" \
 	    --tag "$(APP_DEPLOYER_IMAGE)" \
 	    -f deployer/Dockerfile \
 	    .

--- a/wordpress/deployer/Dockerfile
+++ b/wordpress/deployer/Dockerfile
@@ -1,3 +1,4 @@
+ARG MARKETPLACE_TOOLS_TAG
 FROM launcher.gcr.io/google/debian9 AS build
 
 RUN apt-get update \
@@ -14,7 +15,7 @@ RUN cat /tmp/schema.yaml \
     && mv /tmp/schema.yaml.new /tmp/schema.yaml
 
 
-FROM gcr.io/cloud-marketplace-tools/k8s/deployer_envsubst
+FROM gcr.io/cloud-marketplace-tools/k8s/deployer_envsubst:$MARKETPLACE_TOOLS_TAG
 
 COPY manifest /data/manifest
 COPY apptest/deployer /data-test/


### PR DESCRIPTION
I had assumed that this was the case, but it wasn't which was the breakage in my development flow that allowed for https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/pull/235.